### PR TITLE
chore(ci): add hadolint Dockerfile linting and SonarCloud integration

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -57,6 +57,17 @@ jobs:
       - name: Run go build
         run: go build -v ./...
 
+  hadolint:
+    name: Lint Dockerfile
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v4
+      - name: Run hadolint
+        uses: hadolint/hadolint-action@v3.1.0
+        with:
+          dockerfile: deploy/dockerfile
+
   scan:
     name: SonarCloud Scan
     runs-on: ubuntu-latest

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -68,16 +68,28 @@ jobs:
         uses: hadolint/hadolint-action@v3.1.0
         with:
           dockerfile: deploy/dockerfile
+          format: sonarqube
+          output-file: hadolint-report.json
+          no-fail: true
+      - name: Upload hadolint report
+        uses: actions/upload-artifact@v4
+        with:
+          name: hadolint-report
+          path: hadolint-report.json
 
   scan:
     name: SonarCloud Scan
     runs-on: ubuntu-latest
-    needs: [version]
+    needs: [version, hadolint]
     steps:
       - name: Check out code
         uses: actions/checkout@v4
         with:
           fetch-depth: 0 # Shallow clones should be disabled for a better relevancy of analysis
+      - name: Download hadolint report
+        uses: actions/download-artifact@v4
+        with:
+          name: hadolint-report
       - name: Set up Go 1.x
         uses: actions/setup-go@v5
         with:
@@ -101,6 +113,7 @@ jobs:
         with:
           args: >
             -Dsonar.projectVersion=${{ needs.version.outputs.FullSemVer }}
+            -Dsonar.externalIssuesReportPaths=hadolint-report.json
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # Needed to get PR information, if any
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,6 +7,7 @@ on:
       - beta
       - "feature/*"
       - "fix/*"
+      - "danstis/*"
   pull_request:
     types: [opened, synchronize, reopened]
   workflow_dispatch:


### PR DESCRIPTION
### **User description**
Add a Hado lint job to the workflow for linting the Dockerfile, enhance integration with report upload, and support for SonarCloud. This integration improves code quality by identifying potential issues in the Dockerfile. 

Fixes #24


___

### **PR Type**
Enhancement


___

### **Description**
- Add hadolint job for Dockerfile linting

- Upload hadolint report artifact

- Integrate report into SonarCloud scan

- Trigger workflow on danstis/* branches


___

### Diagram Walkthrough


```mermaid
flowchart LR
  pushPR["Push/PR (main, beta, feature/*, fix/*, danstis/*)"] --> versionJob["version job"]
  pushPR --> hadolintJob["hadolint: lint Dockerfile"]
  hadolintJob -- "upload hadolint-report.json" --> artifact["artifact: hadolint-report"]
  versionJob --> scanJob["SonarCloud scan job"]
  artifact --> scanJob
  scanJob -- "use external issues" --> sonar["SonarCloud analysis"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>build.yml</strong><dd><code>Add hadolint job and integrate with SonarCloud</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/build.yml

<ul><li>Add hadolint job to lint <code>deploy/dockerfile</code>.<br> <li> Upload hadolint report as artifact in SonarQube format.<br> <li> Make scan job depend on hadolint and consume report.<br> <li> Add <code>danstis/*</code> to push branch triggers.</ul>


</details>


  </td>
  <td><a href="https://github.com/danstis/lotto-numbers/pull/157/files#diff-5c3fa597431eda03ac3339ae6bf7f05e1a50d6fc7333679ec38e21b337cb6721">+26/-1</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

