### PR TITLE
fix: defer statement handling and fatal exit logging

### DIFF
--- a/cmd/lotto-numbers/main.go
+++ b/cmd/lotto-numbers/main.go
@@ -1,3 +1,4 @@
+// Package main is the entry point for the lotto-numbers web service.
 package main
 
 import (

--- a/internal/generator/generator.go
+++ b/internal/generator/generator.go
@@ -1,3 +1,4 @@
+// Package generator provides lottery number generation functionality.
 package generator
 
 import (

--- a/internal/handlers/handlers.go
+++ b/internal/handlers/handlers.go
@@ -1,3 +1,4 @@
+// Package handlers implements HTTP request handlers for the lotto-numbers API.
 package handlers
 
 import (

--- a/internal/handlers/routes.go
+++ b/internal/handlers/routes.go
@@ -24,13 +24,13 @@ func SetupRoutes(ctx context.Context, r *mux.Router) {
 	webFs, err := fs.Sub(static, "web")
 	if err != nil {
 		span.RecordError(err)
-		log.Fatalf("Unable to create sub filesystem: %v", err)
+		log.Panicf("Unable to create sub filesystem: %v", err)
 	}
 	// Create a sub filesystem for the assets directory.
 	assetsFs, err := fs.Sub(static, "web/assets")
 	if err != nil {
 		span.RecordError(err)
-		log.Fatalf("Unable to create sub filesystem for assets: %v", err)
+		log.Panicf("Unable to create sub filesystem for assets: %v", err)
 	}
 
 	r.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {

--- a/internal/middleware/middleware.go
+++ b/internal/middleware/middleware.go
@@ -1,3 +1,4 @@
+// Package middleware provides HTTP middleware functions for request logging and processing.
 package middleware
 
 import (

--- a/internal/models/models.go
+++ b/internal/models/models.go
@@ -1,3 +1,4 @@
+// Package models defines data structures used throughout the lotto-numbers application.
 package models
 
 // Define your models here. For example:

--- a/internal/tracing/tracing.go
+++ b/internal/tracing/tracing.go
@@ -1,3 +1,4 @@
+// Package tracing configures and initializes OpenTelemetry tracing with Uptrace.
 package tracing
 
 import (

--- a/internal/tracing/tracing.go
+++ b/internal/tracing/tracing.go
@@ -15,7 +15,7 @@ func SetupTracing() (trace.Tracer, func(ctx context.Context)) {
 	// Retrieve the uptrace environment variables.
 	dsn := os.Getenv("UPTRACE_DSN")
 	if dsn == "" {
-		log.Fatalf("UPTRACE_DSN environment variable not set")
+		log.Panicf("UPTRACE_DSN environment variable not set")
 	}
 	environment := os.Getenv("ENVIRONMENT")
 	if environment == "" {

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -1,3 +1,4 @@
+// Package version holds the application version string.
 package version
 
 var Version = "0.0.0-development"


### PR DESCRIPTION
### **User description**
Replace fatal log statements with panic log statements to improve error handling in route and tracing setup.


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Replace fatal logs with panic logs

- Improve error handling in routes setup

- Harden tracing setup for missing DSN


___

### Diagram Walkthrough


```mermaid
flowchart LR
  Routes["handlers/routes.go: switch log.Fatalf -> log.Panicf"]
  Tracing["tracing/tracing.go: switch log.Fatalf -> log.Panicf"]
  App["App runtime continues after panic (recoverable context)"]

  Routes -- "error on fs.Sub" --> App
  Tracing -- "missing UPTRACE_DSN" --> App
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>routes.go</strong><dd><code>Use panic logging for filesystem setup errors</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

internal/handlers/routes.go

<ul><li>Replace <code>log.Fatalf</code> with <code>log.Panicf</code> for web fs error.<br> <li> Replace <code>log.Fatalf</code> with <code>log.Panicf</code> for assets fs error.</ul>


</details>


  </td>
  <td><a href="https://github.com/danstis/lotto-numbers/pull/161/files#diff-9d9c807ecaf6c850a75b4cad9871941046afab7dfbfd1bb90bacbfaa88820830">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>tracing.go</strong><dd><code>Panic on missing tracing DSN instead of fatal</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

internal/tracing/tracing.go

- Replace `log.Fatalf` with `log.Panicf` when `UPTRACE_DSN` missing.


</details>


  </td>
  <td><a href="https://github.com/danstis/lotto-numbers/pull/161/files#diff-5c08615768a3813362491c2c5e72ae4f99be0022510caf59811250af03d35b8e">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

