### PR TITLE
fix: replace time-seeded RNG with global rand.Shuffle to fix biased distribution BSOD-30

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -86,6 +86,9 @@ jobs:
         with:
           args: --issues-exit-code=0 --output.checkstyle.path=golangci-lint.out
       - name: Run govulncheck
+        # govulncheck@latest (v1.4.0) panics on Go 1.26 generic TypeParam via x/tools@v0.46.0.
+        # Using continue-on-error until upstream fixes the ForEachElement panic.
+        continue-on-error: true
         run: |
           go install golang.org/x/vuln/cmd/govulncheck@latest
           govulncheck ./...

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -86,9 +86,6 @@ jobs:
         with:
           args: --issues-exit-code=0 --output.checkstyle.path=golangci-lint.out
       - name: Run govulncheck
-        # govulncheck@latest (v1.4.0) panics on Go 1.26 generic TypeParam via x/tools@v0.46.0.
-        # Using continue-on-error until upstream fixes the ForEachElement panic.
-        continue-on-error: true
         run: |
           go install golang.org/x/vuln/cmd/govulncheck@latest
           govulncheck ./...

--- a/internal/generator/generator.go
+++ b/internal/generator/generator.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"math/rand"
 	"sort"
-	"time"
 )
 
 // GetNumbers generates a list of lottery numbers based on the given parameters.
@@ -22,16 +21,18 @@ func GetNumbers(numbersList []int, lines, numPerLine int) [][]int {
 		return nil // Not enough numbers to generate a line, zero lines requested, or non-positive numPerLine
 	}
 
+	pool := make([]int, len(numbersList))
+	copy(pool, numbersList)
+
 	lotteryNumbers := make([][]int, 0)
 	linesMap := make(map[string]bool)
-	localRand := rand.New(rand.NewSource(time.Now().UnixNano()))
 	for i := 0; i < lines; i++ {
-		localRand.Shuffle(len(numbersList), func(i, j int) {
-			numbersList[i], numbersList[j] = numbersList[j], numbersList[i]
+		rand.Shuffle(len(pool), func(i, j int) {
+			pool[i], pool[j] = pool[j], pool[i]
 		})
 		uniqueLine := make(map[int]bool)
 		line := make([]int, 0, numPerLine)
-		for _, num := range numbersList[:numPerLine] {
+		for _, num := range pool[:numPerLine] {
 			if !uniqueLine[num] {
 				uniqueLine[num] = true
 				line = append(line, num)

--- a/internal/generator/generator.go
+++ b/internal/generator/generator.go
@@ -24,9 +24,11 @@ func GetNumbers(numbersList []int, lines, numPerLine int) [][]int {
 	pool := make([]int, len(numbersList))
 	copy(pool, numbersList)
 
-	lotteryNumbers := make([][]int, 0)
+	lotteryNumbers := make([][]int, 0, lines)
 	linesMap := make(map[string]bool)
-	for i := 0; i < lines; i++ {
+	// Safety cap prevents an infinite loop when lines > C(len(pool), numPerLine).
+	maxAttempts := lines * (len(pool) + 1) * 2
+	for attempts := 0; len(lotteryNumbers) < lines && attempts < maxAttempts; attempts++ {
 		rand.Shuffle(len(pool), func(i, j int) {
 			pool[i], pool[j] = pool[j], pool[i]
 		})

--- a/internal/generator/generator_test.go
+++ b/internal/generator/generator_test.go
@@ -2,6 +2,7 @@ package generator
 
 import (
 	"fmt"
+	"math"
 	"sort"
 	"testing"
 
@@ -149,6 +150,43 @@ func TestGenerateLotteryNumbers_NotEnoughNumbers(t *testing.T) {
 		})
 	}
 }
+func TestGetNumbers_UniformDistribution(t *testing.T) {
+	numbersList := []int{1, 2, 3, 4, 5, 6, 7, 8, 9, 10}
+	numPerLine := 5
+	iterations := 10000
+
+	freq := make(map[int]int)
+	for i := 0; i < iterations; i++ {
+		result := GetNumbers(numbersList, 1, numPerLine)
+		if len(result) == 0 {
+			t.Fatal("GetNumbers returned no results")
+		}
+		for _, num := range result[0] {
+			freq[num]++
+		}
+	}
+
+	// Each number should appear roughly iterations*numPerLine/len(numbersList) times.
+	expected := float64(iterations*numPerLine) / float64(len(numbersList))
+	// Allow ±15% deviation — chi-square at 99.9% for 9 df is ~27, this is a looser guard.
+	tolerance := expected * 0.15
+	for num, count := range freq {
+		if math.Abs(float64(count)-expected) > tolerance {
+			t.Errorf("number %d appeared %d times, expected ~%.0f (±%.0f)", num, count, expected, tolerance)
+		}
+	}
+}
+
+func TestGetNumbers_DoesNotMutateInput(t *testing.T) {
+	original := []int{1, 2, 3, 4, 5, 6, 7, 8, 9, 10}
+	input := make([]int, len(original))
+	copy(input, original)
+
+	GetNumbers(input, 5, 5)
+
+	assert.Equal(t, original, input, "GetNumbers must not modify the caller's slice")
+}
+
 func TestGenerateLotteryNumbers_InvalidInputs(t *testing.T) {
 	tests := []struct {
 		name        string

--- a/internal/generator/generator_test.go
+++ b/internal/generator/generator_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"math"
 	"sort"
+	"sync"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -156,7 +157,7 @@ func TestGetNumbers_UniformDistribution(t *testing.T) {
 	iterations := 10000
 
 	freq := make(map[int]int)
-	for i := 0; i < iterations; i++ {
+	for range iterations {
 		result := GetNumbers(numbersList, 1, numPerLine)
 		if len(result) == 0 {
 			t.Fatal("GetNumbers returned no results")
@@ -174,6 +175,48 @@ func TestGetNumbers_UniformDistribution(t *testing.T) {
 		if math.Abs(float64(count)-expected) > tolerance {
 			t.Errorf("number %d appeared %d times, expected ~%.0f (±%.0f)", num, count, expected, tolerance)
 		}
+	}
+}
+
+// TestGetNumbers_ConcurrentCallsDiverseResults is the regression test for the
+// time-seeded RNG bug. With the old rand.New(rand.NewSource(time.Now().UnixNano()))
+// pattern, goroutines that land in the same nanosecond receive identical seeds and
+// thus produce identical shuffle sequences — most results collapse to the same
+// combination. With the auto-seeded global rand the results must be diverse.
+func TestGetNumbers_ConcurrentCallsDiverseResults(t *testing.T) {
+	numbersList := []int{1, 2, 3, 4, 5, 6, 7, 8, 9, 10}
+	numPerLine := 5
+	goroutines := 200
+
+	type result struct{ line string }
+	results := make(chan result, goroutines)
+
+	var wg sync.WaitGroup
+	for range goroutines {
+		wg.Go(func() {
+			r := GetNumbers(numbersList, 1, numPerLine)
+			if len(r) > 0 {
+				results <- result{fmt.Sprint(r[0])}
+			}
+		})
+	}
+	wg.Wait()
+	close(results)
+
+	seen := make(map[string]int)
+	total := 0
+	for r := range results {
+		seen[r.line]++
+		total++
+	}
+
+	// C(10,5) = 252 possible combinations. With 200 concurrent calls and a
+	// properly seeded RNG we expect a wide spread; with a time-colliding seed
+	// almost all calls collapse to the same combination.
+	// Require at least 50 distinct combinations out of 200.
+	if len(seen) < 50 {
+		t.Errorf("concurrent calls produced only %d distinct combinations out of %d total; "+
+			"expected ≥50 (possible RNG seed collision)", len(seen), total)
 	}
 }
 

--- a/internal/handlers/handlers.go
+++ b/internal/handlers/handlers.go
@@ -15,6 +15,8 @@ import (
 	"github.com/danstis/lotto-numbers/internal/models"    // Import the models package
 )
 
+const maxLines = 100
+
 // GetLotteryNumbers handles the request to generate lottery numbers.
 func GetLotteryNumbers(w http.ResponseWriter, r *http.Request) {
 	// Parse query parameters
@@ -38,6 +40,10 @@ func GetLotteryNumbers(w http.ResponseWriter, r *http.Request) {
 	// Validate the parameters before calling the generator
 	if lines <= 0 || numPerLine <= 0 {
 		sendHTTPError(w, "Invalid input: 'lines' and 'numPerLine' must be positive numbers", nil, http.StatusBadRequest)
+		return
+	}
+	if lines > maxLines {
+		sendHTTPError(w, fmt.Sprintf("Invalid input: 'lines' must be <= %d", maxLines), nil, http.StatusBadRequest)
 		return
 	}
 

--- a/internal/handlers/handlers_test.go
+++ b/internal/handlers/handlers_test.go
@@ -57,6 +57,15 @@ func TestGetLotteryNumbers(t *testing.T) {
 			wantErrContains: "",
 		},
 		{
+			name:            "Too many lines parameter",
+			query:           "?lines=101",
+			wantStatusCode:  http.StatusBadRequest,
+			wantLines:       0,
+			wantNumPerLine:  0,
+			wantSubset:      nil,
+			wantErrContains: "'lines' must be <= 100",
+		},
+		{
 			name:            "Valid numPerLine parameter",
 			query:           "?numPerLine=5",
 			wantStatusCode:  http.StatusOK,


### PR DESCRIPTION
### **User description**
## Summary

- **Root cause**: `rand.New(rand.NewSource(time.Now().UnixNano()))` was called on every request. Concurrent requests arriving within the same nanosecond received identical seeds, producing identical shuffle sequences. This caused certain number combinations (those produced by the most-common seed values) to appear far more often than others, breaking the expected uniform distribution.
- **Fix**: Replace the time-seeded local RNG with the package-level `rand.Shuffle`, which in Go 1.20+ uses an automatically and securely seeded global source. The `time` import is removed.
- **Bonus fix**: `GetNumbers` now works on a local copy of `numbersList`, preventing the function from silently mutating the caller's slice.

## Test plan

- [ ] `TestGetNumbers_UniformDistribution` — generates 10,000 samples and asserts every number appears within ±15% of the expected frequency
- [ ] `TestGetNumbers_DoesNotMutateInput` — verifies the input slice is unchanged after the call
- [ ] All 33 existing tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

### **PR Type**
Bug fix, Tests


___

### **Description**
- Replace time-seeded RNG with Go's global `rand.Shuffle` to fix biased distribution

- Copy input slice before shuffling to prevent mutation of caller's data

- Add `TestGetNumbers_UniformDistribution` test with 10,000 sample frequency check

- Add `TestGetNumbers_DoesNotMutateInput` test to verify slice immutability


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Time-seeded RNG\n(rand.NewSource(time.Now().UnixNano()))"] -- "concurrent requests\nsame nanosecond = same seed" --> B["Biased number distribution"]
  C["Global rand.Shuffle\n(Go 1.20+ auto-seeded)"] -- "fixes" --> D["Uniform distribution"]
  E["Input slice copy\n(pool := copy(numbersList))"] -- "prevents" --> F["Caller slice mutation"]
  B -- "replaced by" --> C
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>generator.go</strong><dd><code>Fix biased RNG and prevent input slice mutation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

internal/generator/generator.go

<ul><li>Remove <code>time</code> import and time-seeded local RNG <br>(<code>rand.New(rand.NewSource(...))</code>)<br> <li> Replace <code>localRand.Shuffle</code> with package-level <code>rand.Shuffle</code> using Go <br>1.20+ global source<br> <li> Create a local <code>pool</code> copy of <code>numbersList</code> before shuffling to avoid <br>mutating caller's slice</ul>


</details>


  </td>
  <td><a href="https://github.com/danstis/lotto-numbers/pull/252/files#diff-93b5439df693e891da6c7aef54a4dfc3bd2f00a0aab7cc4d352345ce3c3c4981">+6/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>generator_test.go</strong><dd><code>Add distribution uniformity and immutability tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

internal/generator/generator_test.go

<ul><li>Add <code>math</code> import for frequency deviation calculations<br> <li> Add <code>TestGetNumbers_UniformDistribution</code> running 10,000 iterations with <br>±15% tolerance check<br> <li> Add <code>TestGetNumbers_DoesNotMutateInput</code> verifying input slice is <br>unchanged after call</ul>


</details>


  </td>
  <td><a href="https://github.com/danstis/lotto-numbers/pull/252/files#diff-747e1d24aa851c4c9ff21f52d42fc01b91e87d4b7ab6c2840ee62d6fca27be70">+38/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

