### PR TITLE
fix: pin Go toolchain to 1.26.4 for govulncheck compatibility

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -53,7 +53,7 @@ jobs:
       - name: Set up Go 1.x
         uses: actions/setup-go@v6
         with:
-          go-version: ^1.26
+          go-version: 1.26.4
         id: go
       - name: Run go build
         run: go build -v ./...
@@ -67,7 +67,7 @@ jobs:
       - name: Set up Go 1.x
         uses: actions/setup-go@v6
         with:
-          go-version: ^1.26
+          go-version: 1.26.4
         id: go
       - name: Run hadolint
         uses: hadolint/hadolint-action@v3.3.0
@@ -87,8 +87,7 @@ jobs:
           args: --issues-exit-code=0 --output.checkstyle.path=golangci-lint.out
       - name: Run govulncheck
         run: |
-          go install golang.org/x/vuln/cmd/govulncheck@latest
-          govulncheck ./...
+          GOTOOLCHAIN=go1.26.4+auto go run golang.org/x/vuln/cmd/govulncheck@latest ./...
 
   scan:
     name: SonarCloud Scan
@@ -106,7 +105,7 @@ jobs:
       - name: Set up Go 1.x
         uses: actions/setup-go@v6
         with:
-          go-version: ^1.26
+          go-version: 1.26.4
         id: go
       - name: Test (Go)
         run: go test -v -coverprofile=coverage.out -covermode=count -json ./... | tee test-report.out

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -54,7 +54,7 @@ jobs:
     - name: Set up Go 1.x
       uses: actions/setup-go@v6
       with:
-        go-version: ^1.26
+        go-version: 1.26.4
       id: go
     - name: Run go build
       run: go build -v ./...

--- a/deploy/dockerfile
+++ b/deploy/dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.26-alpine AS builder
+FROM golang:1.26.4-alpine AS builder
 
 # hadolint ignore=DL3018
 RUN apk add --no-cache git

--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,8 @@ module github.com/danstis/lotto-numbers
 
 go 1.26.0
 
+toolchain go1.26.4
+
 require (
 	github.com/gorilla/mux v1.8.1
 	github.com/stretchr/testify v1.11.1


### PR DESCRIPTION
### **User description**
Closes BSOD-33

## Summary
- pin the repo toolchain to Go 1.26.4
- run govulncheck with the Go 1.26.4 toolchain in CI
- pin workflow and Docker build images to Go 1.26.4


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Pin Go version to `1.26.4` across all CI workflows and Docker build

- Add `toolchain go1.26.4` directive to `go.mod`

- Fix `govulncheck` to run with explicit `GOTOOLCHAIN=go1.26.4+auto`


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["go.mod"] -- "toolchain go1.26.4" --> B["Go 1.26.4 Toolchain"]
  C["build.yml"] -- "go-version: 1.26.4" --> B
  D["codeql.yml"] -- "go-version: 1.26.4" --> B
  E["dockerfile"] -- "golang:1.26.4-alpine" --> B
  B -- "GOTOOLCHAIN=go1.26.4+auto" --> F["govulncheck"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>build.yml</strong><dd><code>Pin Go 1.26.4 and fix govulncheck execution in CI</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/build.yml

<ul><li>Pin <code>go-version</code> from <code>^1.26</code> to <code>1.26.4</code> in Build, Lint, and Scan jobs<br> <li> Replace two-step <code>govulncheck</code> install+run with single <br><code>GOTOOLCHAIN=go1.26.4+auto go run</code> command</ul>


</details>


  </td>
  <td><a href="https://github.com/danstis/lotto-numbers/pull/259/files#diff-5c3fa597431eda03ac3339ae6bf7f05e1a50d6fc7333679ec38e21b337cb6721">+4/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>codeql.yml</strong><dd><code>Pin Go 1.26.4 in CodeQL workflow</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/codeql.yml

- Pin `go-version` from `^1.26` to `1.26.4` in CodeQL analysis job


</details>


  </td>
  <td><a href="https://github.com/danstis/lotto-numbers/pull/259/files#diff-12783128521e452af0cfac94b99b8d250413c516ec71fe6d97dbea666ff7ba27">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>dockerfile</strong><dd><code>Pin Docker base image to Go 1.26.4</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

deploy/dockerfile

<ul><li>Update base image from <code>golang:1.26-alpine</code> to <code>golang:1.26.4-alpine</code></ul>


</details>


  </td>
  <td><a href="https://github.com/danstis/lotto-numbers/pull/259/files#diff-01eec17bf4a13dcb405dc9cbe42688af63dae06f7a62ffde327a192bf99302b0">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Dependencies</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>go.mod</strong><dd><code>Add Go 1.26.4 toolchain directive to go.mod</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

go.mod

- Add `toolchain go1.26.4` directive to lock the Go toolchain version


</details>


  </td>
  <td><a href="https://github.com/danstis/lotto-numbers/pull/259/files#diff-33ef32bf6c23acb95f5902d7097b7a1d5128ca061167ec0716715b0b9eeaa5f6">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

